### PR TITLE
Add Discord bridge plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java'
+}
+
+group = 'dev.dfbridge'
+version = '1.0.0'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+    // Paper API
+    maven { url = 'https://repo.papermc.io/repository/maven-public/' }
+    // Optional: if you want to compile against DiscordSRV, uncomment below and ensure artifact is resolvable
+    // maven { url = 'https://jitpack.io' }
+}
+
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT'
+    // compileOnly 'com.github.DiscordSRV:DiscordSRV:1.30.0' // (optional) prefer reflection at runtime
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+jar {
+    archiveBaseName.set('DFDiscordBridge')
+    archiveVersion.set('')
+}
+
+tasks.register('copyPlugin', Copy) {
+    dependsOn build
+    from(layout.buildDirectory.file('libs/DFDiscordBridge.jar'))
+    into(System.getProperty('user.home') + '/server/plugins')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'DF-DiscordBridge'

--- a/src/main/java/dev/dfbridge/DiscordBridgePlugin.java
+++ b/src/main/java/dev/dfbridge/DiscordBridgePlugin.java
@@ -1,0 +1,29 @@
+package dev.dfbridge;
+
+import dev.dfbridge.listeners.AnnounceListener;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class DiscordBridgePlugin extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        getLogger().info("Enabling Discord bridge...");
+
+        // Warn if DiscordSRV is not present (we use reflection at runtime)
+        if (Bukkit.getPluginManager().getPlugin("DiscordSRV") == null) {
+            getLogger().warning("DiscordSRV not found. Messages won't be delivered until it's installed/enabled.");
+        }
+
+        // Register event listener
+        Bukkit.getPluginManager().registerEvents(new AnnounceListener(this), this);
+
+        getLogger().info("Discord bridge ready.");
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("Discord bridge disabled.");
+    }
+}

--- a/src/main/java/dev/dfbridge/events/DFAnnounceEvent.java
+++ b/src/main/java/dev/dfbridge/events/DFAnnounceEvent.java
@@ -1,0 +1,38 @@
+package dev.dfbridge.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class DFAnnounceEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final String type;
+    private final Map<String, String> data;
+
+    public DFAnnounceEvent(String type, Map<String, String> data) {
+        super(true); // async safe: fired from main thread typically; keeping true is fine for safety
+        this.type = type;
+        this.data = data == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(data));
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Map<String, String> getData() {
+        return data;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/dev/dfbridge/listeners/AnnounceListener.java
+++ b/src/main/java/dev/dfbridge/listeners/AnnounceListener.java
@@ -1,0 +1,103 @@
+package dev.dfbridge.listeners;
+
+import dev.dfbridge.DiscordBridgePlugin;
+import dev.dfbridge.events.DFAnnounceEvent;
+import dev.dfbridge.util.MessageFormatter;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+public final class AnnounceListener implements Listener {
+    private final DiscordBridgePlugin plugin;
+
+    public AnnounceListener(DiscordBridgePlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onAnnounce(DFAnnounceEvent event) {
+        FileConfiguration cfg = plugin.getConfig();
+        String channelId = cfg.getString("discord.channel-id", "");
+        if (channelId == null || channelId.isEmpty()) {
+            plugin.getLogger().warning("discord.channel-id is not set.");
+            return;
+        }
+
+        // Resolve template by type path: messages.<typePath>.template
+        String[] parts = event.getType().split("\\.");
+        String template = null;
+        ConfigurationSection msg = cfg.getConfigurationSection("messages");
+        if (msg != null) {
+            ConfigurationSection cursor = msg;
+            for (String p : parts) {
+                cursor = cursor.getConfigurationSection(p);
+                if (cursor == null) break;
+            }
+            if (cursor != null) {
+                template = cursor.getString("template");
+            }
+            if (template == null) {
+                ConfigurationSection def = msg.getConfigurationSection("default");
+                if (def != null) {
+                    template = def.getString("template", "{type} {player}");
+                }
+            }
+        }
+        if (template == null) {
+            template = "{type} {player}";
+        }
+
+        Map<String, String> data = event.getData();
+        ConfigurationSection roles = cfg.getConfigurationSection("roles");
+        String result = MessageFormatter.render(template, data, roles);
+
+        // Apply auto @everyone prefix based on glob patterns
+        List<String> patterns = cfg.getStringList("messages.prefix-groups.everyone.matches");
+        result = MessageFormatter.applyAutoPrefixForGroups(event.getType(), result, patterns);
+
+        sendToDiscord(channelId, result);
+    }
+
+    private void sendToDiscord(String channelId, String content) {
+        try {
+            Class<?> dsrvClass = Class.forName("org.discordsrv.discordsrv.DiscordSRV");
+            Method getPlugin = dsrvClass.getMethod("getPlugin");
+            Object dsrv = getPlugin.invoke(null);
+            if (dsrv == null) {
+                plugin.getLogger().warning("DiscordSRV is not ready.");
+                return;
+            }
+            Method getJda = dsrv.getClass().getMethod("getJda");
+            Object jda = getJda.invoke(dsrv);
+            if (jda == null) {
+                plugin.getLogger().warning("DiscordSRV JDA is not ready.");
+                return;
+            }
+            Method getMainGuild = dsrv.getClass().getMethod("getMainGuild");
+            Object guild = getMainGuild.invoke(dsrv);
+            if (guild == null) {
+                plugin.getLogger().warning("DiscordSRV getMainGuild() returned null.");
+                return;
+            }
+            Method getTextChannelById = guild.getClass().getMethod("getTextChannelById", long.class);
+            Object channel = getTextChannelById.invoke(guild, Long.parseLong(channelId));
+            if (channel == null) {
+                plugin.getLogger().warning("Channel not found: " + channelId);
+                return;
+            }
+            Method sendMessage = channel.getClass().getMethod("sendMessage", CharSequence.class);
+            Object action = sendMessage.invoke(channel, content);
+            Method queue = action.getClass().getMethod("queue");
+            queue.invoke(action);
+        } catch (ClassNotFoundException e) {
+            plugin.getLogger().warning("DiscordSRV class not found. Is the jar installed?");
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to send message via DiscordSRV: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/dev/dfbridge/util/GlobMatcher.java
+++ b/src/main/java/dev/dfbridge/util/GlobMatcher.java
@@ -1,0 +1,28 @@
+package dev.dfbridge.util;
+
+public final class GlobMatcher {
+    private GlobMatcher() {}
+
+    public static boolean matches(String pattern, String text) {
+        // Simple '*' wildcard only
+        String[] parts = pattern.split("\\*", -1);
+        int pos = 0;
+        boolean first = true;
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                first = false;
+                continue;
+            }
+            int index = text.indexOf(part, pos);
+            if (index == -1 || (first && !text.startsWith(part))) {
+                return false;
+            }
+            pos = index + part.length();
+            first = false;
+        }
+        if (!pattern.endsWith("*") && !text.endsWith(parts[parts.length - 1])) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/dev/dfbridge/util/MessageFormatter.java
+++ b/src/main/java/dev/dfbridge/util/MessageFormatter.java
@@ -1,0 +1,72 @@
+package dev.dfbridge.util;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class MessageFormatter {
+    private MessageFormatter() {}
+
+    private static final Pattern ROLE_PATTERN = Pattern.compile("\\{role:([^}]+)\\}");
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\{([a-zA-Z0-9_]+)\\}");
+
+    public static String render(String template, Map<String, String> data, ConfigurationSection rolesSection) {
+        if (template == null) template = "";
+        String result = template;
+
+        // {role:KEY} -> <@&ROLEID>
+        Matcher rm = ROLE_PATTERN.matcher(result);
+        StringBuffer sb = new StringBuffer();
+        while (rm.find()) {
+            String key = rm.group(1);
+            String roleId = rolesSection != null ? rolesSection.getString(key) : null;
+            String replacement = roleId != null && !roleId.isEmpty() ? "<@&" + roleId + ">" : "";
+            rm.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        rm.appendTail(sb);
+        result = sb.toString();
+
+        // {everyone} -> @everyone
+        result = result.replace("{everyone}", "@everyone");
+
+        // {var} replacements
+        Matcher vm = VAR_PATTERN.matcher(result);
+        sb = new StringBuffer();
+        while (vm.find()) {
+            String key = vm.group(1);
+            String replacement = data != null ? data.getOrDefault(key, "") : "";
+            vm.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        vm.appendTail(sb);
+        result = sb.toString();
+
+        return result;
+    }
+
+    /**
+     * Applies automatic @everyone prefix when the given type matches any of the provided glob patterns.
+     * If the message already contains @everyone at the start, no additional prefix is added.
+     *
+     * @param type     event type (e.g., "rift.unstable")
+     * @param message  formatted message to possibly prefix
+     * @param patterns list of glob patterns
+     * @return message with auto prefix applied if matched
+     */
+    public static String applyAutoPrefixForGroups(String type, String message, List<String> patterns) {
+        if (message == null || patterns == null) {
+            return message;
+        }
+        for (String pattern : patterns) {
+            if (GlobMatcher.matches(pattern, type)) {
+                if (!message.startsWith("@everyone")) {
+                    return "@everyone " + message;
+                }
+                return message;
+            }
+        }
+        return message;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,50 @@
+discord:
+  channel-id: ""
+
+roles:
+  winner: "000000000000000001"
+  loser: "000000000000000002"
+
+messages:
+  prefix-groups:
+    everyone:
+      matches:
+        - "rift.*"
+        - "end.*"
+
+  default:
+    template: "{type} {player}"
+
+  upgrade:
+    legendary:
+      template: "전설의 \"{itemName}\" 이(가) 탄생했습니다!"
+    destroy:
+      template: "누군가의 \"{itemName}\" 아이템이 강화에 실패하여 파괴되었습니다."
+
+  clan:
+    absorb:
+      template: "@everyone {role:loser} 가문이 마지막 파일런을 잃고 {role:winner} 가문에게 흡수되었습니다"
+    recruit:
+      template: "@{clan}팀이 \"{player}\" 님을 새로운 가문원으로 영입했습니다!"
+    intrude:
+      template: "팀의 영역에 외부인이 접근했습니다"
+    pylon_destroyed:
+      template: "팀의 파일런이 파괴되었습니다"
+
+  rift:
+    unstable:
+      template: "@everyone 차원의 어딘가가 불안정합니다"
+    strong_energy:
+      template: "@everyone 균열에서 강력한 기운이 감지됩니다!"
+    closed:
+      template: "@everyone 차원의 균열이 닫힙니다."
+
+  end:
+    twitching:
+      template: "@everyone 공허의 기운이 꿈틀거립니다... {minutes}분 뒤 엔드 포탈이 열립니다!"
+    opened:
+      template: "@everyone 엔더 드래곤의 포효가 들려옵니다! 엔드포탈이 활성화되었습니다!"
+    closed:
+      template: "@everyone 엔더 드래곤이 쓰러져 엔드 포탈이 닫혔습니다!"
+    collapse:
+      template: "@everyone 엔드 월드가 {minutes}분 뒤 붕괴를 시작합니다! 서둘러 탈출하세요!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,6 @@
+name: DFDiscordBridge
+main: dev.dfbridge.DiscordBridgePlugin
+version: 1.0.0
+api-version: '1.21'
+softdepend:
+  - DiscordSRV


### PR DESCRIPTION
## Summary
- add Gradle build with Paper API and Java 21 toolchain
- implement DiscordBridge plugin listening for DFAnnounceEvent and forwarding to Discord via DiscordSRV reflection
- support templated messages, role mentions, and auto @everyone prefix via glob rules

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68ac74b6aae88333baf575ce7fc73504